### PR TITLE
Added flag -g for make and make db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ CC		=	gcc
 CFLAGS	+=	-Wall
 CFLAGS	+=	-Wextra
 CFLAGS	+=	-Werror
+CFLAGS	+=	-g
 
 OFLAGS	+=	-fsanitize=address
 OFLAGS	+=	$(shell pkg-config --libs readline) -I $(shell pkg-config --cflags readline)
@@ -85,7 +86,5 @@ norm:
 
 
 # Debugger
-db:
-	$(CC) $(SRCS) -I$(DIR_INC) $(OFLAGS) -g -o $(NAME)
+db:	$(NAME)
 	$(DB) $(NAME)
-


### PR DESCRIPTION
### From the man of `gcc`
```
-g  Produce debugging information in the operating system's native format (stabs, COFF, XCOFF, or DWARF).  GDB can work with
           this debugging information.
```

This flag can be remove at the end of development.