### PR TITLE
created an automated test for compilation

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,17 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: make
+      run: make


### PR DESCRIPTION
This GH action will ensure that when you try to push something to the main branch or make a pr on the main branch it should still compile. Useful when there is no merging conflict but it still doesn't compile.